### PR TITLE
feat: make ContractAddresses type iterable

### DIFF
--- a/ethereum/bindings/src/config.rs
+++ b/ethereum/bindings/src/config.rs
@@ -39,6 +39,25 @@ pub struct ContractAddresses {
     pub winning_probability_oracle: Address,
 }
 
+impl IntoIterator for &ContractAddresses {
+    type IntoIter = std::vec::IntoIter<Address>;
+    type Item = Address;
+
+    fn into_iter(self) -> Self::IntoIter {
+        vec![
+            self.token,
+            self.channels,
+            self.announcements,
+            self.node_safe_registry,
+            self.ticket_price_oracle,
+            self.winning_probability_oracle,
+            self.node_stake_factory,
+            self.module_implementation,
+        ]
+            .into_iter()
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct SingleNetworkContractAddresses {
     pub indexer_start_block_number: u32,

--- a/ethereum/bindings/src/config.rs
+++ b/ethereum/bindings/src/config.rs
@@ -49,12 +49,13 @@ impl IntoIterator for &ContractAddresses {
             self.channels,
             self.announcements,
             self.node_safe_registry,
+            self.node_safe_migration,
             self.ticket_price_oracle,
             self.winning_probability_oracle,
             self.node_stake_factory,
             self.module_implementation,
         ]
-            .into_iter()
+        .into_iter()
     }
 }
 


### PR DESCRIPTION
As in title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iteration support for contract addresses so you can directly iterate over configured addresses. This makes accessing and processing address collections simpler and more convenient, improving workflows that enumerate or transform contract addresses across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->