### PR TITLE
feat: update deployment addresses of anvil-localhost

### DIFF
--- a/ethereum/bindings/contracts-addresses.json
+++ b/ethereum/bindings/contracts-addresses.json
@@ -2,15 +2,15 @@
   "networks": {
     "anvil-localhost": {
       "addresses": {
-        "announcements": "0x0165878A594ca255338adfa4d48449f69242Eb8F",
-        "channels": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
-        "module_implementation": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
-        "node_safe_migration": "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
-        "node_safe_registry": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
-        "node_stake_factory": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
-        "ticket_price_oracle": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-        "token": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
-        "winning_probability_oracle": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
+        "announcements": "0xfd5c1c0f5299b51282a0bcb0465ff7f536f320a9",
+        "channels": "0x37406b53c672083cd70a2eb44732c7276ede2049",
+        "module_implementation": "0x8c4c7942a75754ebe57c8baa2341d1f4922124c5",
+        "node_safe_migration": "0x42c47173d81fb51fc23a1be3804e0cba4972e6dd",
+        "node_safe_registry": "0x81c9a8b5c1fd9e4b5c134dab131ebc0b35d25994",
+        "node_stake_factory": "0x51dfbbd2612d76ecc5a157f3c236b2b1cdffa733",
+        "ticket_price_oracle": "0x376b4a2243b74667ea186fc89114355599e6b5c4",
+        "token": "0xcf4c708eeda485f3fe5ceacec86eae46ef3fc87d",
+        "winning_probability_oracle": "0x0ecb0e77e6bde494665993dad5b3b14c026c08bd"
       },
       "chain_id": 31337,
       "environment_type": "local",


### PR DESCRIPTION
### Description

Update the deployed contract addresses according to the deployment order of `ContractInstances::deploy_for_testing` assuming the deployer account is the first account in alloy, i.e. `ChainKeypair::from_secret(anvil.keys()[0].to_bytes().as_ref())?;`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal contract address configurations for local development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->