### PR TITLE
feat: New deployment of announcements (implementation and proxy)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -1793,9 +1793,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1814,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64",
  "bytes",
@@ -2019,9 +2019,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -2609,9 +2609,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -3323,9 +3323,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",

--- a/ethereum/bindings/Cargo.toml
+++ b/ethereum/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-bindings"
-version = "4.3.0"
+version = "4.4.0"
 description = "This package only exists to automate the export and generation of Rust bindings into the HOPR project"
 edition = "2021"
 homepage = "https://hoprnet.org/"

--- a/ethereum/bindings/contracts-addresses.json
+++ b/ethereum/bindings/contracts-addresses.json
@@ -18,7 +18,7 @@
     },
     "rotsee": {
       "addresses": {
-        "announcements": "0x5afe60f4f74159f8F68dadCE6202b938cDa80Dad",
+        "announcements": "0x225b4b6FFe08228db1182946b5F9e905f1A19A4D",
         "channels": "0x5bD809bDBAa8D3d5f37743Ae86BFef766dEE56b6",
         "module_implementation": "0x1167FB204298799B0B9E98896D58958cAEd164B0",
         "node_safe_migration": "0x74dfCdF50340b772696cAeF3F3Bc4cD776D37E8A",
@@ -34,7 +34,7 @@
     },
     "debug-staging": {
       "addresses": {
-        "announcements": "0x191Ee0D1494eB159A5F758bC7c05E434cFaFF6e1",
+        "announcements": "0x060DbC55867f0FFc20E69f9273113AeB90F4d049",
         "channels": "0x7a33eb3900DB3e02A4C149E49dBc1F0359921B16",
         "module_implementation": "0x3b008Cb90D252b731ceB8952a6Ed78B84Ab31Ea3",
         "node_safe_migration": "0x593eA8942E8b1D36F7714a15D43b5914DEF7B449",


### PR DESCRIPTION
### Description

Fixed the wrong token address set in the multisig abstract contract at initialization of the announcement proxy. 

#### Deployments
##### Rotsee
`0x225b4b6FFe08228db1182946b5F9e905f1A19A4D`
##### Debug-staging
`0x060DbC55867f0FFc20E69f9273113AeB90F4d049`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 4.4.0
  * Updated contract addresses for announcements infrastructure

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->