### PR TITLE
feat: Use depot runners and publish library

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -19,7 +19,7 @@ jobs:
       unit_coverage: true
       unconditional: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/cache-deps.yaml
+++ b/.github/workflows/cache-deps.yaml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   cargo:
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04
     timeout-minutes: 60
     steps:
       - name: Harden Runner

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths: [".github/**"]
-  merge_group:
-    types: [checks_requested]
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-zizmor
   cancel-in-progress: true

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -19,6 +19,6 @@ jobs:
       security-events: write
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   cleanup-pr:
     name: Remove cache
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Harden Runner

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -30,7 +30,6 @@ jobs:
       version_type: pr
       architecture: ${{ matrix.architecture }}
       cachix_cache_name: contracts
-      build_file: ethereum/bindings/Cargo.toml
       package_name: hopr-bindings
       runner: ${{ matrix.runner }}
     secrets:

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -17,17 +17,25 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: self-hosted-hoprnet-bigger
+            runner: depot-ubuntu-24.04-4
             build_command: nix build -L .#lib-hopr-bindings-x86_64-linux
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@5ef5e50e028143b53da6545c1ca92477b70f42fc # build-library-v1
+          - architecture: aarch64-linux
+            runner: depot-ubuntu-24.04-arm-4
+            build_command: nix build -L .#lib-hopr-bindings-aarch64-linux
+          - architecture: aarch64-darwin
+            runner: depot-macos-15
+            build_command: nix build -L .#lib-hopr-bindings-aarch64-darwin
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v2
     permissions:
       contents: read
     with:
       source_branch: ${{ github.event.pull_request.base.ref }}
+      version_type: pr
       architecture: ${{ matrix.architecture }}
       cachix_cache_name: contracts
       build_file: ethereum/bindings/Cargo.toml
       build_command: ${{ matrix.build_command }}
+      package_name: hopr-bindings
       runner: ${{ matrix.runner }}
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -42,7 +50,7 @@ jobs:
       unit_coverage: true
       unconditional: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -18,13 +18,10 @@ jobs:
         include:
           - architecture: x86_64-linux
             runner: depot-ubuntu-24.04-4
-            build_command: nix build -L .#lib-hopr-bindings-x86_64-linux
           - architecture: aarch64-linux
             runner: depot-ubuntu-24.04-arm-4
-            build_command: nix build -L .#lib-hopr-bindings-aarch64-linux
           - architecture: aarch64-darwin
             runner: depot-macos-15
-            build_command: nix build -L .#lib-hopr-bindings-aarch64-darwin
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v2
     permissions:
       contents: read
@@ -34,7 +31,6 @@ jobs:
       architecture: ${{ matrix.architecture }}
       cachix_cache_name: contracts
       build_file: ethereum/bindings/Cargo.toml
-      build_command: ${{ matrix.build_command }}
       package_name: hopr-bindings
       runner: ${{ matrix.runner }}
     secrets:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,7 +1,5 @@
 name: PR
 on:
-  merge_group:
-    types: [checks_requested]
   pull_request:
     types:
       - opened

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -136,7 +136,7 @@ jobs:
             required_label: "binary:aarch64-linux"
           - architecture: aarch64-darwin
             runner: depot-macos-15
-            required_label: binary:aarch64-darwin
+            required_label: "binary:aarch64-darwin"
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v2
     permissions:
       contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ jobs:
   validate-pr-title:
     name: Validate title
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04
     permissions:
       pull-requests: read
     steps:
@@ -42,7 +42,7 @@ jobs:
   label:
     name: Add labels
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
       issues: write
@@ -75,8 +75,8 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@bbd22e57cf954c15f0a6051d59329857809141dd # workflow-checks-v1
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      runner_small: self-hosted-hoprnet-small
-      runner_large: self-hosted-hoprnet-bigger
+      runner_small: depot-ubuntu-24.04
+      runner_large: depot-ubuntu-24.04-4
       deps: false
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -91,14 +91,14 @@ jobs:
       nightly_test_command: "nix build -L .#test-nightly"
       unit_coverage: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-24.04-4
       test_timeout: 60
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
   tests-smart-contracts:
     name: Smart Contracts
-    runs-on: self-hosted-hoprnet-bigger
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 60
     if: github.event.pull_request.draft == false
     env:
@@ -132,41 +132,29 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: self-hosted-hoprnet-bigger
+            runner: depot-ubuntu-24.04-4
             build_command: nix build -L .#lib-hopr-bindings-x86_64-linux
             required_label: ""
           - architecture: aarch64-linux
-            runner: self-hosted-hoprnet-bigger
+            runner: depot-ubuntu-24.04-arm-4
             build_command: nix build -L .#lib-hopr-bindings-aarch64-linux
             required_label: "binary:aarch64-linux"
           - architecture: aarch64-darwin
-            runner: macos-15-xlarge
+            runner: depot-macos-15
             build_command: nix build -L .#lib-hopr-bindings-aarch64-darwin
             required_label: binary:aarch64-darwin
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@5ef5e50e028143b53da6545c1ca92477b70f42fc # build-library-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v2
     permissions:
       contents: read
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
+      version_type: commit
       architecture: ${{ matrix.architecture }}
       cachix_cache_name: contracts
       build_file: ethereum/bindings/Cargo.toml
       build_command: ${{ matrix.build_command }}
+      package_name: hopr-bindings
       runner: ${{ matrix.runner }}
       enabled: ${{ matrix.required_label == '' || contains(github.event.pull_request.labels.*.name, matrix.required_label) }}
-    secrets:
-      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-  publish-dry-run:
-    name: Publish
-    needs: [tests]
-    uses: hoprnet/hopr-workflows/.github/workflows/publish-crates.yaml@e4fadaa70234b9d734d5c51b6900602e55492ce2 # workflow-publish-crates-v3
-    permissions:
-      contents: read
-    with:
-      source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      package: hopr-bindings
-      version_type: commit
-      cachix_cache_name: contracts
-      runner: self-hosted-hoprnet-bigger
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -115,12 +115,11 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           persist-credentials: false
-      - name: Set up Google Cloud Credentials
-        id: auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+      - name: Setup Nix
+        uses: hoprnet/hopr-workflows/actions/setup-nix@setup-nix-v1
         with:
-          token_format: "access_token"
-          credentials_json: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
+          cachix_cache_name: contracts
+          cachix_auth_token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Run tests
         env:
           HOPR_NETWORK: anvil-localhost

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -130,15 +130,12 @@ jobs:
         include:
           - architecture: x86_64-linux
             runner: depot-ubuntu-24.04-4
-            build_command: nix build -L .#lib-hopr-bindings-x86_64-linux
             required_label: ""
           - architecture: aarch64-linux
             runner: depot-ubuntu-24.04-arm-4
-            build_command: nix build -L .#lib-hopr-bindings-aarch64-linux
             required_label: "binary:aarch64-linux"
           - architecture: aarch64-darwin
             runner: depot-macos-15
-            build_command: nix build -L .#lib-hopr-bindings-aarch64-darwin
             required_label: binary:aarch64-darwin
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v2
     permissions:
@@ -149,7 +146,6 @@ jobs:
       architecture: ${{ matrix.architecture }}
       cachix_cache_name: contracts
       build_file: ethereum/bindings/Cargo.toml
-      build_command: ${{ matrix.build_command }}
       package_name: hopr-bindings
       runner: ${{ matrix.runner }}
       enabled: ${{ matrix.required_label == '' || contains(github.event.pull_request.labels.*.name, matrix.required_label) }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -145,7 +145,6 @@ jobs:
       version_type: commit
       architecture: ${{ matrix.architecture }}
       cachix_cache_name: contracts
-      build_file: ethereum/bindings/Cargo.toml
       package_name: hopr-bindings
       runner: ${{ matrix.runner }}
       enabled: ${{ matrix.required_label == '' || contains(github.event.pull_request.labels.*.name, matrix.required_label) }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,50 +18,31 @@ concurrency:
 jobs:
   build-library:
     name: Library ${{ matrix.architecture }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - architecture: x86_64-linux
-            runner: self-hosted-hoprnet-bigger
-            build_command: nix build -L .#lib-hopr-bindings-x86_64-linux
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@5ef5e50e028143b53da6545c1ca92477b70f42fc # build-library-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v2
     permissions:
       contents: read
     with:
       source_branch: ${{ github.ref_name }}
-      architecture: ${{ matrix.architecture }}
+      version_type: release
+      architecture: x86_64-linux
       cachix_cache_name: contracts
       build_file: ethereum/bindings/Cargo.toml
-      build_command: ${{ matrix.build_command }}
-      runner: ${{ matrix.runner }}
-    secrets:
-      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-  publish:
-    name: Publish
-    needs: [build-library]
-    uses: hoprnet/hopr-workflows/.github/workflows/publish-crates.yaml@e4fadaa70234b9d734d5c51b6900602e55492ce2 # workflow-publish-crates-v3
-    permissions:
-      contents: read
-    with:
-      source_branch: ${{ github.ref_name }}
-      package: hopr-bindings
-      version_type: release
-      cachix_cache_name: contracts
-      runner: self-hosted-hoprnet-bigger
+      build_command: nix build -L .#lib-hopr-bindings-x86_64-linux
+      package_name: hopr-bindings
+      runner: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       cargo_registry_token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   release:
     name: Close release
     needs:
-      - publish
-    runs-on: self-hosted-hoprnet-small
+      - build-library
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@4e3c270b51ed1817bc0b0f6996dfc8a7b0e757c1 # release-version-v2
+        uses: hoprnet/hopr-workflows/actions/release-version@release-version-v4
         with:
           source_branch: ${{ github.ref_name }}
           file: ethereum/bindings/Cargo.toml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   build-library:
-    name: Library ${{ matrix.architecture }}
+    name: Build Library
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v2
     permissions:
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,6 @@ jobs:
       version_type: release
       architecture: x86_64-linux
       cachix_cache_name: contracts
-      build_file: ethereum/bindings/Cargo.toml
       package_name: hopr-bindings
       runner: depot-ubuntu-24.04-4
     secrets:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,6 @@ jobs:
       architecture: x86_64-linux
       cachix_cache_name: contracts
       build_file: ethereum/bindings/Cargo.toml
-      build_command: nix build -L .#lib-hopr-bindings-x86_64-linux
       package_name: hopr-bindings
       runner: depot-ubuntu-24.04-4
     secrets:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.8.0"
+version = "4.9.0"
 dependencies = [
  "alloy",
  "anyhow",

--- a/ethereum/contracts/test/node-stake/permissioned-modules/NodeManagementModule.t.sol
+++ b/ethereum/contracts/test/node-stake/permissioned-modules/NodeManagementModule.t.sol
@@ -150,7 +150,6 @@ contract HoprNodeManagementModuleTest is
 
     function testFuzz_AddNodeAndFundNode(address account) public initializeModuleProxy(address(1)) {
         assumeNotPrecompile(account);
-        assumeNotForgeAddress(account);
         vm.assume(account != address(0) && account.code.length == 0); // EOA only
         vm.assume(account != 0x000000000000000000636F6e736F6c652e6c6f67); // avoid conflict with console.log precompile
 

--- a/ethereum/contracts/test/node-stake/permissioned-modules/NodeManagementModule.t.sol
+++ b/ethereum/contracts/test/node-stake/permissioned-modules/NodeManagementModule.t.sol
@@ -150,6 +150,7 @@ contract HoprNodeManagementModuleTest is
 
     function testFuzz_AddNodeAndFundNode(address account) public initializeModuleProxy(address(1)) {
         assumeNotPrecompile(account);
+        assumeNotForgeAddress(account);
         vm.assume(account != address(0) && account.code.length == 0); // EOA only
         address owner = moduleProxy.owner();
         vm.deal(owner, 2 ether);


### PR DESCRIPTION
- Uses depot runners
- Changes the publish library workflow to embed it into the `build-library.yaml` workflow.
- Removes merge_group

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated CI runners to standardized depot-provided environments for consistency and reliability.
  * Upgraded the build system to a new reusable build-library version with broader architecture support.
  * Simplified and consolidated the release pipeline into a single build-and-release flow.
  * Streamlined workflow configurations and job inputs to improve maintainability and reduce duplication.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hoprnet/contracts/pull/101)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->