### PR TITLE
feat(ci): grant id-token permission for crates.io trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v2
     permissions:
       contents: read
+      id-token: write
     with:
       source_branch: ${{ github.ref_name }}
       version_type: release
@@ -30,7 +31,6 @@ jobs:
       runner: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      cargo_registry_token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   release:
     name: Close release
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@build-library-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6c5db2cd898f1f2c8fdae39498b6d7b3ee7d0258 # build-library-v3
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

- Add \`id-token: write\` to the \`build-library\` job in \`release.yaml\` so the OIDC token exchange in \`hoprnet/hopr-workflows\` can succeed
- Remove \`cargo_registry_token\` secret — no longer needed
- Bump \`build-library\` reference to \`6c5db2c # build-library-v3\`

~~Depends on: hoprnet/hopr-workflows#80~~ (merged)