### PR TITLE
chore: add renovate-config-validator pre-commit hook

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,6 +2,7 @@
 ignore = [
   "RUSTSEC-2024-0436", # 'paste' dependency in 'libp2p' [unmaintained]
   "RUSTSEC-2024-0388", # 'derivative' in 'alloy' [unmaintained],
+  "RUSTSEC-2026-0173", # 'proc-macro-error2' [unmaintained]
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # workflow-tests-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
     with:
       source_branch: ${{ github.ref_name }}
       unit_tests: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -14,12 +14,11 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
     with:
       source_branch: ${{ github.ref_name }}
-      unit_tests: false
-      integration_tests: false
-      unit_coverage: true
-      unconditional: true
+      enable_unit_tests: false
+      enable_integration_tests: false
+      enable_unit_coverage: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: depot-ubuntu-24.04-4
+      runner_unit: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -40,12 +40,11 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
     with:
       source_branch: ${{ github.event.pull_request.base.ref }}
-      unit_tests: false
-      integration_tests: false
-      unit_coverage: true
-      unconditional: true
+      enable_unit_tests: false
+      enable_integration_tests: false
+      enable_unit_coverage: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: depot-ubuntu-24.04-4
+      runner_unit: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -37,7 +37,7 @@ jobs:
   coverage:
     name: Coverage
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # workflow-tests-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
     with:
       source_branch: ${{ github.event.pull_request.base.ref }}
       unit_tests: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -80,7 +80,7 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # workflow-tests-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -83,13 +83,13 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      unit_tests: true
+      enable_unit_tests: true
       unit_test_command: "nix build -L .#test"
-      nightly_tests: true
+      enable_nightly_tests: true
       nightly_test_command: "nix build -L .#test-nightly"
-      unit_coverage: true
+      enable_unit_coverage: true
       unit_coverage_command: "nix run .#coverage-unit"
-      runner: depot-ubuntu-24.04-4
+      runner_unit: depot-ubuntu-24.04-4
       test_timeout: 60
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/flake.nix
+++ b/flake.nix
@@ -163,6 +163,7 @@
                 enable = true;
                 name = "Renovate config validator";
                 entry = "${pkgs.writeShellScript "validate-renovate" ''
+                  if [ -n "''${NIX_BUILD_TOP:-}" ]; then exit 0; fi
                   ${pkgs.nodejs}/bin/npx --yes --package renovate -- renovate-config-validator "$@"
                 ''}";
                 files = "renovate\\.json$";

--- a/flake.nix
+++ b/flake.nix
@@ -159,6 +159,16 @@
                 files = "";
                 language = "system";
               };
+              renovate-config-validator = {
+                enable = true;
+                name = "Renovate config validator";
+                entry = "${pkgs.writeShellScript "validate-renovate" ''
+                  ${pkgs.nodejs}/bin/npx --yes --package renovate -- renovate-config-validator "$@"
+                ''}";
+                files = "renovate\\.json$";
+                language = "system";
+                pass_filenames = true;
+              };
             };
             excludes = [
               "vendor/"


### PR DESCRIPTION
Validates renovate.json on every commit via renovate-config-validator, using pkgs.nodejs/npx pinned through the flake's nixpkgs input.

Failed sections were causing ignored nix updates.