### PR TITLE
chore(coderabbit): tighten defaults — assertive, high-level, comments-only

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,3 @@
----
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-US"
 early_access: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+tone_instructions: >-
+  Be pedantic and rigorous. Focus on substantive correctness, security, architectural concerns, and high-level design issues. Skip cosmetic or stylistic nits. Never submit an approving review — comments only.
+reviews:
+  profile: "assertive"
+  # Do NOT enable request_changes_workflow: with it off, CodeRabbit only
+  # submits COMMENT reviews — never APPROVED or REQUEST_CHANGES.
+  request_changes_workflow: false
+  high_level_summary: false
+  review_status: false
+  commit_status: false
+  changed_files_summary: false
+  sequence_diagrams: false
+  related_issues: false
+  related_prs: false
+  suggested_labels: false
+  auto_apply_labels: false
+  suggested_reviewers: false
+  auto_assign_reviewers: false
+  assess_linked_issues: true
+  poem: false
+  collapse_walkthrough: true
+  path_filters:
+    - "!vendor/**"
+  auto_review:
+    enabled: true
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+    drafts: false
+    base_branches:
+      - "master"
+      - "release/.*"
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -32,7 +32,7 @@ reviews:
       - "DO NOT MERGE"
     drafts: false
     base_branches:
-      - "master"
+      - "main"
       - "release/.*"
 chat:
   auto_reply: true


### PR DESCRIPTION
Adds `.coderabbit.yaml` to align with the unified CodeRabbit configuration adopted across the hoprnet org.

**Key settings:**
- Profile: `assertive`
- Tone: pedantic, rigorous — substantive correctness and security only, no cosmetic nits
- `request_changes_workflow: false` — comments-only reviews (never APPROVED or REQUEST_CHANGES)
- Noise reduction: high-level summary, poem, sequence diagrams, suggested labels/reviewers all disabled
- Auto-review enabled on `master` branches, skips drafts and WIP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration settings to enhance review quality and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->