### PR TITLE
feat(ci): migrate workflows to Workload Identity Provider auth

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -5,13 +5,14 @@ on:
       - main
 permissions:
   contents: read
+  id-token: write
 concurrency:
   group: branches-${{ github.ref_name }}
   cancel-in-progress: false
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}
       enable_unit_tests: false
@@ -21,4 +22,3 @@ jobs:
       runner_unit: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -31,7 +31,7 @@ jobs:
           ref: main
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # master
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # setup-gcp-v4
         with:
           login_artifact_registry: 'true'
           install_sdk: 'true'

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -11,6 +11,10 @@ on:
         description: "Pull request number"
 jobs:
   cleanup-pr:
+    permissions:
+      actions: write
+      contents: read
+      id-token: write
     name: Remove cache
     runs-on: depot-ubuntu-24.04
     timeout-minutes: 10
@@ -27,11 +31,10 @@ jobs:
           ref: main
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@12c56020e16036982e6cc529848edeedfc705865 # master
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # master
         with:
-          google-credentials: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
-          login-artifact-registry: 'true'
-          install-sdk: 'true'
+          login_artifact_registry: 'true'
+          install_sdk: 'true'
       - name: Cleanup Github pipeline cache
         run: |
           cacheKeysForPR=($(gh actions-cache list -R ${{ github.repository }} -B refs/pull/${{ github.event.inputs.pr_number }}/merge | cut -f 1 | tr '\n' ' '))

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -5,6 +5,9 @@ on:
       - closed
     branches:
       - main
+permissions:
+  contents: read
+  id-token: write # zizmor: ignore[excessive-permissions]
 concurrency:
   group: merge-${{ github.event.pull_request.base.ref }}
   cancel-in-progress: false
@@ -37,7 +40,7 @@ jobs:
   coverage:
     name: Coverage
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.base.ref }}
       enable_unit_tests: false
@@ -47,7 +50,6 @@ jobs:
       runner_unit: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
   notify:
     name: Notify failure
     needs:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,7 @@ on:
       - ready_for_review
 permissions:
   contents: read
+  id-token: write # zizmor: ignore[excessive-permissions]
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
   cancel-in-progress: true
@@ -80,7 +81,7 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true
@@ -93,7 +94,6 @@ jobs:
       test_timeout: 60
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
   tests-smart-contracts:
     name: Smart Contracts
     runs-on: depot-ubuntu-24.04-4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       id-token: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1 # release-version-v4
+        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
         with:
           source_branch: ${{ github.ref_name }}
           file: ethereum/bindings/Cargo.toml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,9 +38,10 @@ jobs:
     runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@53b6df9c98ee8a327d7533e76cd9aafcac6a1c2e # release-version-v4
+        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1 # release-version-v4
         with:
           source_branch: ${{ github.ref_name }}
           file: ethereum/bindings/Cargo.toml
@@ -51,5 +52,4 @@ jobs:
           zulip_email: ${{ secrets.ZULIP_EMAIL }}
           zulip_channel: "HOPRd"
           zulip_topic: "Releases"
-          gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
-          github_token: ${{ secrets.GH_RUNNER_TOKEN }}
+          github_app_private_key: ${{ secrets.GH_APP_HOPRNET_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6c5db2cd898f1f2c8fdae39498b6d7b3ee7d0258 # build-library-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # build-library-v3
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

- Pins all `hoprnet/hopr-workflows` action/workflow refs to new OIDC-enabled SHAs
- Removes legacy `gcp_service_account`, `google_credentials`, and `GH_RUNNER_TOKEN` PAT from workflow inputs
- Adds `id-token: write` permission to every consumer job for OIDC token minting
- Adds `github_app_private_key: ${{ secrets.GH_APP_HOPRNET_BOT_PRIVATE_KEY }}` to all `release-version` invocations

Part of the org-wide WIF migration following the GitHub security incident. Reference: hoprnet/blokli#377