### PR TITLE
feat(ci): add actionlint + pinact pre-commit hooks for workflow validation

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+---
+self-hosted-runner:
+  labels:
+    - depot-ubuntu-24.04
+    - depot-ubuntu-24.04-4

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,3 @@
----
 self-hosted-runner:
   labels:
     - depot-ubuntu-24.04

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,5 @@ self-hosted-runner:
   labels:
     - depot-ubuntu-24.04
     - depot-ubuntu-24.04-4
+    - depot-ubuntu-24.04-arm-4
+    - depot-macos-15

--- a/.github/workflows/cache-deps.yaml
+++ b/.github/workflows/cache-deps.yaml
@@ -37,7 +37,7 @@ jobs:
           PRIVATE_CARGO_REGISTRY_PROXY_URL: ${{ secrets.PRIVATE_CARGO_REGISTRY_PROXY_URL }}
         run: "cat >> .cargo/config.toml<< EOF        \n[source.hopr-cargo-registry-cache]\nregistry = \"sparse+${PRIVATE_CARGO_REGISTRY_PROXY_URL}\"\n    #magic___^_^___line\n[source.crates-io]\nreplace-with = \"hopr-cargo-registry-cache\"\nEOF\n    #magic___^_^___line\n"
       - name: Install Nix
-        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -37,8 +37,8 @@ jobs:
           install_sdk: 'true'
       - name: Cleanup Github pipeline cache
         run: |
-          cacheKeysForPR=($(gh actions-cache list -R ${{ github.repository }} -B refs/pull/${{ github.event.inputs.pr_number }}/merge | cut -f 1 | tr '\n' ' '))
-          for cacheKey in $cacheKeysForPR
+          mapfile -t cacheKeysForPR < <(gh actions-cache list -R "${{ github.repository }}" -B "refs/pull/${{ github.event.inputs.pr_number }}/merge" | cut -f 1)
+          for cacheKey in "${cacheKeysForPR[@]}"
           do
-            gh actions-cache delete $cacheKey -R hoprnet/contracts -B refs/pull/${{ github.event.inputs.pr_number }}/merge --confirm
+            gh actions-cache delete "$cacheKey" -R hoprnet/contracts -B "refs/pull/${{ github.event.inputs.pr_number }}/merge" --confirm
           done

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           disable-sudo: true
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -36,9 +36,12 @@ jobs:
           login_artifact_registry: 'true'
           install_sdk: 'true'
       - name: Cleanup Github pipeline cache
+        env:
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
         run: |
-          mapfile -t cacheKeysForPR < <(gh actions-cache list -R "${{ github.repository }}" -B "refs/pull/${{ github.event.inputs.pr_number }}/merge" | cut -f 1)
+          mapfile -t cacheKeysForPR < <(gh actions-cache list -R "$REPO" -B "refs/pull/$PR_NUMBER/merge" | cut -f 1)
           for cacheKey in "${cacheKeysForPR[@]}"
           do
-            gh actions-cache delete "$cacheKey" -R hoprnet/contracts -B "refs/pull/${{ github.event.inputs.pr_number }}/merge" --confirm
+            gh actions-cache delete "$cacheKey" -R "$REPO" -B "refs/pull/$PR_NUMBER/merge" --confirm
           done

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -39,6 +39,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mapfile -t cacheKeysForPR < <(gh actions-cache list -R "$REPO" -B "refs/pull/$PR_NUMBER/merge" | cut -f 1)
           for cacheKey in "${cacheKeysForPR[@]}"

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -28,6 +28,7 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
+      id-token: write
     with:
       source_branch: ${{ github.event.pull_request.base.ref }}
       version_type: pr

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -25,7 +25,7 @@ jobs:
             runner: depot-ubuntu-24.04-arm-4
           - architecture: aarch64-darwin
             runner: depot-macos-15
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@64cb8ba34ff2e8caa43e366207d0cb1faa8d43d4 # build-library-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -137,7 +137,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             required_label: "binary:aarch64-darwin"
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@64cb8ba34ff2e8caa43e366207d0cb1faa8d43d4 # build-library-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -140,6 +140,7 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
+      id-token: write
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       version_type: commit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # build-library-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
       id-token: write

--- a/flake.nix
+++ b/flake.nix
@@ -162,10 +162,7 @@
               renovate-config-validator = {
                 enable = true;
                 name = "Renovate config validator";
-                entry = "${pkgs.writeShellScript "validate-renovate" ''
-                  if [ -n "''${NIX_BUILD_TOP:-}" ]; then exit 0; fi
-                  ${pkgs.nodejs}/bin/npx --yes --package renovate -- renovate-config-validator "$@"
-                ''}";
+                entry = "${pkgs.renovate}/bin/renovate-config-validator";
                 files = "renovate\\.json$";
                 language = "system";
                 pass_filenames = true;
@@ -175,7 +172,15 @@
                 enable = true;
                 name = "pinact";
                 description = "Check GitHub Action refs are SHA-pinned and resolvable";
-                entry = "${pkgs.pinact}/bin/pinact run --check";
+                entry = "${pkgs.writeShellScript "pinact-check" ''
+                  token="''${GITHUB_TOKEN:-$(${pkgs.gh}/bin/gh auth token 2>/dev/null || true)}"
+                  if [ -z "$token" ]; then
+                    echo "pinact: skipping — no GITHUB_TOKEN and gh not authenticated" >&2
+                    exit 0
+                  fi
+                  export GITHUB_TOKEN="$token"
+                  exec ${pkgs.pinact}/bin/pinact run --check
+                ''}";
                 files = "^\\.github/workflows/.*\\.ya?ml$";
                 language = "system";
                 pass_filenames = false;

--- a/flake.nix
+++ b/flake.nix
@@ -262,6 +262,7 @@
               foundry-bin
               sqlite
               gnuplot
+              cargo-release
               zizmor
               yq-go
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -281,6 +281,7 @@
               treefmtWrapper = config.treefmt.build.wrapper;
               treefmtPrograms = pkgs.lib.attrValues config.treefmt.build.programs;
               extraPackages = with pkgs; [
+                cargo-release
                 zizmor
               ];
             };

--- a/flake.nix
+++ b/flake.nix
@@ -170,6 +170,16 @@
                 language = "system";
                 pass_filenames = true;
               };
+              actionlint.enable = true;
+              pinact = {
+                enable = true;
+                name = "pinact";
+                description = "Check GitHub Action refs are SHA-pinned and resolvable";
+                entry = "${pkgs.pinact}/bin/pinact run --check";
+                files = "\\.ya?ml$";
+                language = "system";
+                pass_filenames = false;
+              };
             };
             excludes = [
               "vendor/"
@@ -236,6 +246,7 @@
             shellHook = ''
               echo "Running pre-commit checks..."
               ${pre-commit-check.shellHook}
+              export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
 
               if ! { [ -f ethereum/contracts/foundry.toml ] && grep -q "solc = \"${solcDefault}/bin/solc\"" ethereum/contracts/foundry.toml; }; then
                 echo "Generating foundry.toml file!" >&2

--- a/flake.nix
+++ b/flake.nix
@@ -245,8 +245,8 @@
             treefmtPrograms = pkgs.lib.attrValues config.treefmt.build.programs;
             shellHook = ''
               echo "Running pre-commit checks..."
-              ${pre-commit-check.shellHook}
               export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+              ${pre-commit-check.shellHook}
 
               if ! { [ -f ethereum/contracts/foundry.toml ] && grep -q "solc = \"${solcDefault}/bin/solc\"" ethereum/contracts/foundry.toml; }; then
                 echo "Generating foundry.toml file!" >&2
@@ -257,6 +257,7 @@
               unset SOURCE_DATE_EPOCH
             '';
             extraPackages = with pkgs; [
+              gh
               solcDefault
               foundry-bin
               sqlite

--- a/flake.nix
+++ b/flake.nix
@@ -176,7 +176,7 @@
                 name = "pinact";
                 description = "Check GitHub Action refs are SHA-pinned and resolvable";
                 entry = "${pkgs.pinact}/bin/pinact run --check";
-                files = "\\.ya?ml$";
+                files = "^\\.github/workflows/.*\\.ya?ml$";
                 language = "system";
                 pass_filenames = false;
               };
@@ -246,7 +246,7 @@
             shellHook = ''
               echo "Running pre-commit checks..."
               ${pre-commit-check.shellHook}
-              export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+              export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
 
               if ! { [ -f ethereum/contracts/foundry.toml ] && grep -q "solc = \"${solcDefault}/bin/solc\"" ethereum/contracts/foundry.toml; }; then
                 echo "Generating foundry.toml file!" >&2


### PR DESCRIPTION
Pins all remaining action refs to SHAs and adds actionlint + pinact pre-commit hooks via the flake. Depends on: WIF migration PR must merge first so pinact --check passes on the hopr-workflows refs.