### PR TITLE
fix(ci): refresh hopr-workflows pins to 0.10.1 to fix release publish

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.10.1
     with:
       source_branch: ${{ github.ref_name }}
       enable_unit_tests: false

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -11,7 +11,7 @@ permissions:
   security-events: write
 jobs:
   zizmor:
-    uses: hoprnet/hopr-workflows/.github/workflows/checks-zizmor.yaml@64cb8ba34ff2e8caa43e366207d0cb1faa8d43d4 # workflow-checks-zizmor-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/checks-zizmor.yaml@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.10.1
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -31,7 +31,7 @@ jobs:
           ref: main
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # setup-gcp-v4
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.10.1
         with:
           login_artifact_registry: 'true'
           install_sdk: 'true'

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -25,7 +25,7 @@ jobs:
             runner: depot-ubuntu-24.04-arm-4
           - architecture: aarch64-darwin
             runner: depot-macos-15
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # build-library-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.10.1
     permissions:
       contents: read
       id-token: write
@@ -41,7 +41,7 @@ jobs:
   coverage:
     name: Coverage
     if: github.event.pull_request.merged == true
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.10.1
     with:
       source_branch: ${{ github.event.pull_request.base.ref }}
       enable_unit_tests: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -71,7 +71,7 @@ jobs:
           fi
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@64cb8ba34ff2e8caa43e366207d0cb1faa8d43d4 # workflow-checks-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.10.1
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       runner_small: depot-ubuntu-24.04
@@ -81,7 +81,7 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.10.1
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true
@@ -114,7 +114,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           persist-credentials: false
       - name: Setup Nix
-        uses: hoprnet/hopr-workflows/actions/setup-nix@c8d45034bb33307dfda3b4dfcd1fc4000cadc05a # setup-nix-v1
+        uses: hoprnet/hopr-workflows/actions/setup-nix@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.10.1
         with:
           cachix_cache_name: contracts
           cachix_auth_token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -137,7 +137,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             required_label: "binary:aarch64-darwin"
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # build-library-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.10.1
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # build-library-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.10.1
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

- Bumps every `hoprnet/hopr-workflows` reusable-workflow and action reference from stale `0.7.x`/`v1`/`v2` SHAs to `0.10.1` (`fd29bf3`)
- The critical fix is `build-library`: at `0.10.1` it uses **crates.io OIDC trusted publishing** (`rust-lang/crates-io-auth-action`) instead of `secrets.cargo_registry_token`, which does not exist in this repo — this was the direct cause of the [release run failure](https://github.com/hoprnet/contracts/actions/runs/27824114331)
- `flake.nix` already contains `cargo-release` (added in a prior commit), which the new `build-library` requires in the caller's dev shell

> ⚠️ `cache-deps.yaml` appears to have no callers in this repo — flagging as potentially orphaned, but out of scope for this PR.