### PR TITLE
chore(deps): bump hopr-bindings to 4.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.9.0"
+version = "4.9.1"
 dependencies = [
  "alloy",
  "anyhow",

--- a/ethereum/bindings/Cargo.toml
+++ b/ethereum/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-bindings"
-version = "4.9.0"
+version = "4.9.1"
 description = "This package only exists to automate the export and generation of Rust bindings into the HOPR project"
 edition = "2024"
 homepage = "https://hoprnet.org/"


### PR DESCRIPTION
Patch version bump for hopr-bindings (4.9.0 → 4.9.1).