### PR TITLE
fix(deps): ignore nix-lib in dependabot nix updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
       timezone: "UTC"
     cooldown:
       default-days: 7
+    ignore:
+      # nix-lib uses version-pinned refs (github:hoprnet/nix-lib/vX.Y.Z) that
+      # Dependabot compares incorrectly and proposes as a downgrade. Version
+      # upgrades are managed manually alongside breaking API changes.
+      - dependency-name: "nix-lib"
     groups:
       nix-flake-inputs:
         patterns:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2920,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",


### PR DESCRIPTION
Dependabot's nix ecosystem support rewrites version-pinned `flake.nix` refs and proposed a downgrade of `nix-lib` from `v1.3.0` to `v1.2.0` (hoprnet/hoprnet#8281), breaking tests that rely on `runNextest` added in v1.3.0. Adds an ignore rule so Dependabot skips `nix-lib` version pins; upgrades remain manual alongside any breaking API changes.

---
**Additional fix**: upgraded `ruint` to 1.20.0 to resolve RUSTSEC-2026-0220 (uint shift overflow).