### PR TITLE
chore: relax constraint on alloy's version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 members = ["ethereum/bindings"]
 
 [workspace.dependencies]
-alloy = { version = "=2.1.1", default-features = false, features = [
+alloy = { version = "2.1.0", default-features = false, features = [
   "essentials",
   "json-rpc",
   "node-bindings",


### PR DESCRIPTION
Alloy's used to be pinned to `=2.1.1` which caused issues resolving the dependencies with other crates pinning another version (`curvy-bindings`).