### PR TITLE
feat: add curvy bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,15 +10,14 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.1.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9677ab3454c237abe6307805bea17a7912b3a516b606c7b4d3d948b9fede137"
+checksum = "d1172e33a862030da77768c11cf17a1f801590de94cf518392b65207f15810c8"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
  "alloy-eips",
- "alloy-ens",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-network",
@@ -212,20 +211,6 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
-]
-
-[[package]]
-name = "alloy-ens"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c3d803649b2023413a5b84892ed3874977dfa8b8d5481dea05488f20f6f4ef"
-dependencies = [
- "alloy-contract",
- "alloy-primitives",
- "alloy-provider",
- "alloy-sol-types",
- "async-trait",
- "thiserror",
 ]
 
 [[package]]
@@ -1383,6 +1368,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "curvy-bindings"
+version = "1.0.0-rc-1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17072d890f37cafa605470488075155c7942be71988fcc157754313a7436c62e"
+dependencies = [
+ "alloy",
+ "anyhow",
+ "hex",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,6 +1965,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "const_format",
+ "curvy-bindings",
  "hex-literal",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ alloy = { version = "2.1.0", default-features = false, features = [
 ] }
 anyhow = "1.0.103"
 const_format = "0.2.36"
+curvy-bindings = "=1.0.0-rc-1"
 hex-literal = "1.1.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_with = { version = "3.21.0" }

--- a/ethereum/bindings/Cargo.toml
+++ b/ethereum/bindings/Cargo.toml
@@ -16,6 +16,7 @@ const_format = { workspace = true }
 [dependencies]
 alloy = { workspace = true, default-features = false, features = ["contract"] }
 anyhow = { workspace = true }
+curvy-bindings = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 hex-literal = { workspace = true }
 serde_with = { workspace = true }

--- a/ethereum/bindings/README.md
+++ b/ethereum/bindings/README.md
@@ -7,9 +7,8 @@ Rust bindings for the [HOPR protocol](https://hoprnet.org/) smart contracts, gen
 [`alloy`](https://github.com/alloy-rs/alloy)'s `sol!`/`abigen!` macros from the Solidity sources and ABIs in
 [`ethereum/contracts`](https://github.com/hoprnet/contracts/tree/main/ethereum/contracts).
 
-This crate only exists to automate that export: it re-generates the bindings whenever the contracts change and
-bundles the addresses they are deployed at, so downstream HOPR Rust code (the node, indexers, tooling) never has to
-hand-write contract call boilerplate.
+This crate automates that export, bundles deployed addresses, and provides HOPR-facing transaction payload helpers,
+so downstream Rust code (the node, indexers, tooling) never has to hand-write contract call boilerplate.
 
 Full API documentation is available on [docs.rs](https://docs.rs/hopr-bindings).
 
@@ -37,6 +36,7 @@ hopr-bindings = "4"
   [Anvil](https://book.getfoundry.sh/anvil/) for testing.
 - [`constants`] — well-known addresses and deployment bytecode for infrastructure the HOPR contracts depend on
   (ERC-1820 registry, [Safe](https://safe.global/) suite, Multicall3).
+- [`curvy`] — typed construction of Curvy transactions used by HOPR, including withdrawal requests.
 - [`error`] — the [`Error`](crate::error::Error) type returned by this crate's helpers.
 - the `hopr-contract-addresses` binary — dumps the bundled `contracts-addresses.json` (see below) to stdout.
 

--- a/ethereum/bindings/src/curvy.rs
+++ b/ethereum/bindings/src/curvy.rs
@@ -7,7 +7,6 @@ use alloy::{
     sol_types::SolCall,
 };
 use curvy_bindings::curvy_aggregator_alpha_v2::CurvyAggregatorAlphaV2::submitWithdrawalRequestCall;
-
 pub use curvy_bindings::{
     constants::WITHDRAWAL_MAX_INPUTS,
     curvy_aggregator_alpha_v2::CurvyAggregatorAlphaV2::CurvyAggregatorAlphaV2Instance,

--- a/ethereum/bindings/src/curvy.rs
+++ b/ethereum/bindings/src/curvy.rs
@@ -38,13 +38,11 @@ pub struct CurvyWithdrawalRequest<const MAX_INPUTS: usize> {
 impl<const MAX_INPUTS: usize> CurvyWithdrawalRequest<MAX_INPUTS> {
     fn public_signals(&self) -> Vec<U256> {
         let mut public_signals = Vec::with_capacity(MAX_INPUTS + 4);
-        public_signals.push(self.token);
+        public_signals.push(self.amount);
         public_signals.extend(self.nullifiers);
-        public_signals.extend([
-            U256::from_be_slice(self.recipient.as_slice()),
-            self.amount,
-            self.notes_root,
-        ]);
+        public_signals.push(self.notes_root);
+        public_signals.push(U256::from_be_slice(self.recipient.as_slice()));
+        public_signals.push(self.token);
         public_signals
     }
 }
@@ -114,12 +112,12 @@ mod tests {
         assert_eq!(
             call.publicSignals,
             vec![
-                request.token,
+                request.amount,
                 request.nullifiers[0],
                 request.nullifiers[1],
-                U256::from_be_slice(request.recipient.as_slice()),
-                request.amount,
                 request.notes_root,
+                U256::from_be_slice(request.recipient.as_slice()),
+                request.token,
             ]
         );
     }

--- a/ethereum/bindings/src/curvy.rs
+++ b/ethereum/bindings/src/curvy.rs
@@ -1,0 +1,127 @@
+//! Transaction payload construction for Curvy contracts used by HOPR.
+
+use alloy::{
+    network::TransactionBuilder,
+    primitives::{Address, U256},
+    rpc::types::TransactionRequest,
+    sol_types::SolCall,
+};
+use curvy_bindings::curvy_aggregator_alpha_v2::CurvyAggregatorAlphaV2::submitWithdrawalRequestCall;
+
+pub use curvy_bindings::{
+    constants::WITHDRAWAL_MAX_INPUTS,
+    curvy_aggregator_alpha_v2::CurvyAggregatorAlphaV2::CurvyAggregatorAlphaV2Instance,
+    portal_factory::{CurvyTypes, PortalFactory::PortalFactoryInstance},
+};
+
+/// Groth16 proof coordinates accepted by the Curvy aggregator.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Groth16Proof {
+    pub a: [U256; 2],
+    pub b: [[U256; 2]; 2],
+    pub c: [U256; 2],
+}
+
+/// Inputs required to construct a Curvy withdrawal transaction.
+///
+/// `MAX_INPUTS` is part of the withdrawal verifier configuration. The fixed-size nullifier array ensures that the
+/// generated public-signal vector always agrees with that configuration.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CurvyWithdrawalRequest<const MAX_INPUTS: usize> {
+    pub proof: Groth16Proof,
+    pub token: U256,
+    pub nullifiers: [U256; MAX_INPUTS],
+    pub recipient: Address,
+    pub amount: U256,
+    pub notes_root: U256,
+}
+
+impl<const MAX_INPUTS: usize> CurvyWithdrawalRequest<MAX_INPUTS> {
+    fn public_signals(&self) -> Vec<U256> {
+        let mut public_signals = Vec::with_capacity(MAX_INPUTS + 4);
+        public_signals.push(self.token);
+        public_signals.extend(self.nullifiers);
+        public_signals.extend([
+            U256::from_be_slice(self.recipient.as_slice()),
+            self.amount,
+            self.notes_root,
+        ]);
+        public_signals
+    }
+}
+
+/// Constructs signable Curvy aggregator transactions without handling keys or proof generation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CurvyPayloadGenerator {
+    aggregator: Address,
+}
+
+impl CurvyPayloadGenerator {
+    pub const fn new(aggregator: Address) -> Self {
+        Self { aggregator }
+    }
+
+    /// Constructs a transaction invoking `submitWithdrawalRequest` on the configured Curvy aggregator.
+    pub fn withdraw<const MAX_INPUTS: usize>(&self, request: CurvyWithdrawalRequest<MAX_INPUTS>) -> TransactionRequest {
+        let call = submitWithdrawalRequestCall {
+            maxInputs: U256::from(MAX_INPUTS),
+            proof_a: request.proof.a,
+            proof_b: request.proof.b,
+            proof_c: request.proof.c,
+            publicSignals: request.public_signals(),
+        };
+
+        TransactionRequest::default()
+            .with_to(self.aggregator)
+            .with_input(call.abi_encode())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::{network::TransactionBuilder, primitives::address, sol_types::SolCall};
+    use curvy_bindings::curvy_aggregator_alpha_v2::CurvyAggregatorAlphaV2::submitWithdrawalRequestCall;
+
+    use super::{CurvyPayloadGenerator, CurvyWithdrawalRequest, Groth16Proof, U256};
+
+    #[test]
+    fn withdrawal_payload_targets_aggregator_and_preserves_circuit_layout() {
+        let aggregator = address!("1111111111111111111111111111111111111111");
+        let recipient = address!("2222222222222222222222222222222222222222");
+        let request = CurvyWithdrawalRequest {
+            proof: Groth16Proof {
+                a: [U256::from(11), U256::from(12)],
+                b: [[U256::from(21), U256::from(22)], [U256::from(23), U256::from(24)]],
+                c: [U256::from(31), U256::from(32)],
+            },
+            token: U256::from(1),
+            nullifiers: [U256::from(41), U256::from(42)],
+            recipient,
+            amount: U256::from(51),
+            notes_root: U256::from(61),
+        };
+
+        let transaction = CurvyPayloadGenerator::new(aggregator).withdraw(request.clone());
+        assert_eq!(TransactionBuilder::to(&transaction), Some(aggregator));
+        let call = submitWithdrawalRequestCall::abi_decode(
+            TransactionBuilder::input(&transaction).expect("withdrawal calldata missing"),
+        )
+        .expect("withdrawal calldata should decode");
+
+        assert_eq!(call.maxInputs, U256::from(2));
+        assert_eq!(call.proof_a, request.proof.a);
+        assert_eq!(call.proof_b, request.proof.b);
+        assert_eq!(call.proof_c, request.proof.c);
+        assert_eq!(
+            call.publicSignals,
+            vec![
+                request.token,
+                request.nullifiers[0],
+                request.nullifiers[1],
+                U256::from_be_slice(request.recipient.as_slice()),
+                request.amount,
+                request.notes_root,
+            ]
+        );
+    }
+}

--- a/ethereum/bindings/src/curvy.rs
+++ b/ethereum/bindings/src/curvy.rs
@@ -13,6 +13,9 @@ pub use curvy_bindings::{
     portal_factory::{CurvyTypes, PortalFactory::PortalFactoryInstance},
 };
 
+/// Number of note inputs accepted by the Curvy withdrawal verifier deployed by HOPR.
+pub const WITHDRAWAL_INPUT_COUNT: usize = 2;
+
 /// Groth16 proof coordinates accepted by the Curvy aggregator.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Groth16Proof {
@@ -23,21 +26,20 @@ pub struct Groth16Proof {
 
 /// Inputs required to construct a Curvy withdrawal transaction.
 ///
-/// `MAX_INPUTS` is part of the withdrawal verifier configuration. The fixed-size nullifier array ensures that the
-/// generated public-signal vector always agrees with that configuration.
+/// The fixed-size nullifier array matches the withdrawal verifier deployed by HOPR.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CurvyWithdrawalRequest<const MAX_INPUTS: usize> {
+pub struct CurvyWithdrawalRequest {
     pub proof: Groth16Proof,
     pub token: U256,
-    pub nullifiers: [U256; MAX_INPUTS],
+    pub nullifiers: [U256; WITHDRAWAL_INPUT_COUNT],
     pub recipient: Address,
     pub amount: U256,
     pub notes_root: U256,
 }
 
-impl<const MAX_INPUTS: usize> CurvyWithdrawalRequest<MAX_INPUTS> {
+impl CurvyWithdrawalRequest {
     fn public_signals(&self) -> Vec<U256> {
-        let mut public_signals = Vec::with_capacity(MAX_INPUTS + 4);
+        let mut public_signals = Vec::with_capacity(WITHDRAWAL_INPUT_COUNT + 4);
         public_signals.push(self.amount);
         public_signals.extend(self.nullifiers);
         public_signals.push(self.notes_root);
@@ -59,9 +61,9 @@ impl CurvyPayloadGenerator {
     }
 
     /// Constructs a transaction invoking `submitWithdrawalRequest` on the configured Curvy aggregator.
-    pub fn withdraw<const MAX_INPUTS: usize>(&self, request: CurvyWithdrawalRequest<MAX_INPUTS>) -> TransactionRequest {
+    pub fn withdraw(&self, request: CurvyWithdrawalRequest) -> TransactionRequest {
         let call = submitWithdrawalRequestCall {
-            maxInputs: U256::from(MAX_INPUTS),
+            maxInputs: WITHDRAWAL_MAX_INPUTS,
             proof_a: request.proof.a,
             proof_b: request.proof.b,
             proof_c: request.proof.c,
@@ -79,7 +81,10 @@ mod tests {
     use alloy::{network::TransactionBuilder, primitives::address, sol_types::SolCall};
     use curvy_bindings::curvy_aggregator_alpha_v2::CurvyAggregatorAlphaV2::submitWithdrawalRequestCall;
 
-    use super::{CurvyPayloadGenerator, CurvyWithdrawalRequest, Groth16Proof, U256};
+    use super::{
+        CurvyPayloadGenerator, CurvyWithdrawalRequest, Groth16Proof, U256, WITHDRAWAL_INPUT_COUNT,
+        WITHDRAWAL_MAX_INPUTS,
+    };
 
     #[test]
     fn withdrawal_payload_targets_aggregator_and_preserves_circuit_layout() {
@@ -105,7 +110,8 @@ mod tests {
         )
         .expect("withdrawal calldata should decode");
 
-        assert_eq!(call.maxInputs, U256::from(2));
+        assert_eq!(WITHDRAWAL_MAX_INPUTS, U256::from(WITHDRAWAL_INPUT_COUNT));
+        assert_eq!(call.maxInputs, WITHDRAWAL_MAX_INPUTS);
         assert_eq!(call.proof_a, request.proof.a);
         assert_eq!(call.proof_b, request.proof.b);
         assert_eq!(call.proof_c, request.proof.c);

--- a/ethereum/bindings/src/lib.rs
+++ b/ethereum/bindings/src/lib.rs
@@ -8,6 +8,7 @@ mod codegen;
 
 pub mod config;
 pub mod constants;
+pub mod curvy;
 pub mod error;
 
 // Generated bindings for every HOPR Solidity contract, re-exported at the crate root, one module

--- a/ethereum/contracts/test/mocks/ERC677Mock.t.sol
+++ b/ethereum/contracts/test/mocks/ERC677Mock.t.sol
@@ -32,7 +32,10 @@ contract ERC677MockTest is Test {
         stdstore.target(address(erc677Mock)).sig(erc677Mock.balanceOf.selector).with_key(sender).checked_write(amount);
         assertEq(erc677Mock.balanceOf(sender), amount);
 
-        stdstore.target(address(erc677Mock)).sig(erc677Mock.allowance.selector).with_key(msgSender).with_key(sender)
+        stdstore.target(address(erc677Mock))
+            .sig(erc677Mock.allowance.selector)
+            .with_key(msgSender)
+            .with_key(sender)
             .checked_write(amount);
         assertEq(erc677Mock.allowance(msgSender, sender), amount);
 
@@ -52,7 +55,10 @@ contract ERC677MockTest is Test {
         stdstore.target(address(erc677Mock)).sig(erc677Mock.balanceOf.selector).with_key(sender).checked_write(amount);
         assertEq(erc677Mock.balanceOf(sender), amount);
 
-        stdstore.target(address(erc677Mock)).sig(erc677Mock.allowance.selector).with_key(msgSender).with_key(sender)
+        stdstore.target(address(erc677Mock))
+            .sig(erc677Mock.allowance.selector)
+            .with_key(msgSender)
+            .with_key(sender)
             .checked_write(amount);
         assertEq(erc677Mock.allowance(msgSender, sender), amount);
 

--- a/ethereum/contracts/test/node-stake/NodeSafeRegistry.t.sol
+++ b/ethereum/contracts/test/node-stake/NodeSafeRegistry.t.sol
@@ -116,7 +116,9 @@ contract HoprNodeSafeRegistryTest is Test, HoprNodeSafeRegistryEvents {
     {
         vm.assume(safe != nodeAddress);
 
-        stdstore.target(address(nodeSafeRegistry)).sig(nodeSafeRegistry.nodeToSafe.selector).with_key(nodeAddress)
+        stdstore.target(address(nodeSafeRegistry))
+            .sig(nodeSafeRegistry.nodeToSafe.selector)
+            .with_key(nodeAddress)
             .checked_write(safe);
 
         vm.prank(nodeAddress);
@@ -134,7 +136,9 @@ contract HoprNodeSafeRegistryTest is Test, HoprNodeSafeRegistryEvents {
     {
         address safeAddress = address(0);
 
-        stdstore.target(address(nodeSafeRegistry)).sig(nodeSafeRegistry.nodeToSafe.selector).with_key(nodeAddress)
+        stdstore.target(address(nodeSafeRegistry))
+            .sig(nodeSafeRegistry.nodeToSafe.selector)
+            .with_key(nodeAddress)
             .checked_write(address(1));
 
         vm.prank(nodeAddress);
@@ -152,7 +156,9 @@ contract HoprNodeSafeRegistryTest is Test, HoprNodeSafeRegistryEvents {
     {
         address nodeAddress = address(0);
 
-        stdstore.target(address(nodeSafeRegistry)).sig(nodeSafeRegistry.nodeToSafe.selector).with_key(nodeAddress)
+        stdstore.target(address(nodeSafeRegistry))
+            .sig(nodeSafeRegistry.nodeToSafe.selector)
+            .with_key(nodeAddress)
             .checked_write(address(1));
 
         vm.prank(nodeAddress);
@@ -190,7 +196,9 @@ contract HoprNodeSafeRegistryTest is Test, HoprNodeSafeRegistryEvents {
     {
         vm.assume(safe != nodeAddress);
 
-        stdstore.target(address(nodeSafeRegistry)).sig(nodeSafeRegistry.nodeToSafe.selector).with_key(nodeAddress)
+        stdstore.target(address(nodeSafeRegistry))
+            .sig(nodeSafeRegistry.nodeToSafe.selector)
+            .with_key(nodeAddress)
             .checked_write(address(0));
 
         vm.prank(nodeAddress);


### PR DESCRIPTION
- Add Curvy Rust bindings and re-export key contract types.
- Add typed payload generation for Curvy withdrawal requests, including Groth16 proofs and public signals.
- Add unit coverage and update documentation.